### PR TITLE
Shorted suffix ovs to o and phy to p

### DIFF
--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -202,18 +202,18 @@ lln_phyiscal_network: physnet3
 # Network virtual patch link configuration.
 
 # Suffix for Open vSwitch bridge names.
-#network_bridge_suffix_ovs:
+network_bridge_suffix_ovs: '-o'
 
 # Prefix for virtual patch interface names.
 #network_patch_prefix:
 
 # Suffix for virtual patch link interface names when connected towards the
 # physical interface.
-#network_patch_suffix_phy:
+network_patch_suffix_phy: '-p'
 
 # Suffix for virtual patch link interface names when connected towards the
 # OVS bridge.
-#network_patch_suffix_ovs:
+network_patch_suffix_ovs: '-o'
 
 ###############################################################################
 # Network routing table configuration.


### PR DESCRIPTION
We are over the 15 character limit, so shortening it down.