### PR TITLE
Use tags for Kolla checkout

### DIFF
--- a/etc/kayobe/kolla.yml
+++ b/etc/kayobe/kolla.yml
@@ -15,7 +15,7 @@ kolla_source_url: https://github.com/stackhpc/kolla
 
 # Version (branch, tag, etc.) of Kolla source code repository if type is
 # 'source'.
-kolla_source_version: origin/stackhpc/rocky
+kolla_source_version: refs/tags/cumulus/7.0.1.1
 
 # Path to virtualenv in which to install kolla.
 #kolla_venv:
@@ -37,7 +37,7 @@ kolla_ansible_source_url: https://github.com/RSE-Cambridge/kolla-ansible
 
 # Version (branch, tag, etc.) of Kolla Ansible source code repository if type
 # is 'source'.
-kolla_ansible_source_version: origin/cumulus/rocky
+kolla_ansible_source_version: refs/tags/cumulus/7.0.1.1
 
 # Path to virtualenv in which to install kolla-ansible.
 #kolla_ansible_venv:
@@ -73,7 +73,7 @@ kolla_docker_namespace: rse-cambridge
 #kolla_docker_registry_password:
 
 # Kolla OpenStack release version. This should be a Docker image tag.
-#kolla_openstack_release:
+kolla_openstack_release: cumulus/7.0.1.1
 
 # Dict mapping names of sources to their definitions for
 # kolla_install_type=source. See kolla.common.config for details.

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -17,3 +17,38 @@ cinder_backend_ceph: "yes"
 # TODO: how to build these?
 #magnum_tag: pike2
 #keystone_tag: pike2
+
+# Container image tags.
+# These should be allowed to change independently, as services are updated.
+cron_tag: rocky
+ceph_tag: rocky
+cinder_tag: rocky
+elasticsearch_tag: rocky
+fluentd_tag: rocky
+glance_tag: rocky
+grafana_tag: rocky
+haproxy_tag: rocky
+heat_tag: rockt
+horizon_tag: rocky
+influxdb_tag: rocky
+ironic_tag: rocky
+iscsid_tag: rocky
+kafka_tag: rocky
+keepalived_tag: rocky
+keystone_tag: rocky
+kibana_tag: rocky
+kolla_toolbox_tag: rocky
+logstash_tag: rocky
+manila_tag: rocky
+mariadb_tag: rocky
+memcached_tag: rocky
+monasca_tag: rocky
+monasca_notification_tag: rocky
+monasca_persister_tag: rocky
+neutron_tag: rocky
+nova_tag: rocky
+openvswitch_tag: rocky
+prometheus-tag: rocky
+rabbitmq_tag: rocky
+storm_tag: rocky
+zookeeper_tag: rocky


### PR DESCRIPTION
With this change we can ensure that we don't unintentionally deploy
patches that have been merged into the cumulus/rocky branch of
kolla-ansible and that we can upgrade Kolla docker images
individually.

The tag format is cumulus/{kolla-release}.{downstream_patch_number}.

Eg. cumulus/7.0.1.1 is the 7.0.1 release of Kolla, with a backported
patch set. If we developed or backported a second patch set to the
7.0.1 release, the tag would change to cumulus/7.0.1.2.