### PR TITLE
Add symlinks that are necessary for custom playbooks

### DIFF
--- a/etc/kayobe/ansible/filter_plugins
+++ b/etc/kayobe/ansible/filter_plugins
@@ -1,0 +1,1 @@
+../../../../kayobe/ansible/filter_plugins/

--- a/etc/kayobe/ansible/group_vars
+++ b/etc/kayobe/ansible/group_vars
@@ -1,0 +1,1 @@
+../../../../kayobe/ansible/group_vars/

--- a/etc/kayobe/ansible/test_plugins
+++ b/etc/kayobe/ansible/test_plugins
@@ -1,0 +1,1 @@
+../../../../kayobe/ansible/test_plugins/


### PR DESCRIPTION
see: https://kayobe.readthedocs.io/en/latest/custom-ansible-playbooks.html

This adds the constraint that the kayobe source tree must be stored at the same
level in the filesystem as the kayobe config, eg:

/path/to/kayobe
/path/to/kayobe-config