### PR TITLE
Split up log indicies for auditing

### DIFF
--- a/etc/kayobe/kolla/config/fluentd/filter/02-audit.conf
+++ b/etc/kayobe/kolla/config/fluentd/filter/02-audit.conf
@@ -3,3 +3,10 @@
     capitalize_regex_backreference yes
     rewriterule1 python_module ^oslo.messaging.notification.+$ openstack_audit
 </match>
+
+<filter openstack_audit>
+    @type parser
+    format json
+    key_name Payload
+    reserve_data true
+</filter>

--- a/etc/kayobe/kolla/config/fluentd/filter/02-audit.conf
+++ b/etc/kayobe/kolla/config/fluentd/filter/02-audit.conf
@@ -1,0 +1,5 @@
+<match openstack_python>
+    @type rewrite_tag_filter
+    capitalize_regex_backreference yes
+    rewriterule1 python_module ^oslo.messaging.notification.+$ openstack_audit
+</match>

--- a/etc/kayobe/kolla/config/fluentd/output/01-es.conf
+++ b/etc/kayobe/kolla/config/fluentd/output/01-es.conf
@@ -2,8 +2,10 @@
     @type copy
     <store>
        @type elasticsearch
-       host 10.205.0.1
-       port 9200
+       host {% raw %}{{ elasticsearch_address }}
+{% endraw %}
+       port {% raw %}{{ elasticsearch_port }}
+{% endraw %}
        logstash_format true
        logstash_prefix audit
        flush_interval 15s
@@ -14,10 +16,13 @@
     @type copy
     <store>
        @type elasticsearch
-       host 10.205.0.1
-       port 9200
+       host {% raw %}{{ elasticsearch_address }}
+{% endraw %}
+       port {% raw %}{{ elasticsearch_port }}
+{% endraw %}
        logstash_format true
-       logstash_prefix flog
+       logstash_prefix {% raw %}{{ kibana_log_prefix }}
+{% endraw %}
        flush_interval 15s
     </store>
 </match>
@@ -26,8 +31,10 @@
     @type copy
     <store>
        @type elasticsearch
-       host 10.205.0.1
-       port 9200
+       host {% raw %}{{ elasticsearch_address }}
+{% endraw %}
+       port {% raw %}{{ elasticsearch_port }}
+{% endraw %}
        logstash_format true
        logstash_prefix unmatched
        flush_interval 15s

--- a/etc/kayobe/kolla/config/fluentd/output/01-es.conf
+++ b/etc/kayobe/kolla/config/fluentd/output/01-es.conf
@@ -1,4 +1,16 @@
-<match **>
+<match openstack_audit>
+    @type copy
+    <store>
+       @type elasticsearch
+       host 10.205.0.1
+       port 9200
+       logstash_format true
+       logstash_prefix audit
+       flush_interval 15s
+    </store>
+</match>
+
+<match *.**>
     @type copy
     <store>
        @type elasticsearch
@@ -6,6 +18,18 @@
        port 9200
        logstash_format true
        logstash_prefix flog
+       flush_interval 15s
+    </store>
+</match>
+
+<match **>
+    @type copy
+    <store>
+       @type elasticsearch
+       host 10.205.0.1
+       port 9200
+       logstash_format true
+       logstash_prefix unmatched
        flush_interval 15s
     </store>
 </match>


### PR DESCRIPTION
Here we tag all oslo messaging audit notifications and send them
to a separate index.

After that, we have use the default match pattern from upstream, and
anything which doesn't match goes to an unmatched index.