### PR TITLE
Add Cambridge ilab network to seed node

### DIFF
--- a/etc/kayobe/inventory/group_vars/seed/network-interfaces
+++ b/etc/kayobe/inventory/group_vars/seed/network-interfaces
@@ -30,6 +30,9 @@ storage_mgmt_net_interface: "{{ provision_oc_net_interface }}.{{ storage_mgmt_ne
 # storage_mgmt_net_bridge_ports:
 # storage_mgmt_net_bond_slaves:
 
+# Admin backdoor to seed node
+ilab_net_interface: "{{ provision_oc_net_interface }}.{{ ilab_net_vlan }}"
+
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.
 workaround_ansible_issue_8743: yes

--- a/etc/kayobe/network-allocation.yml
+++ b/etc/kayobe/network-allocation.yml
@@ -203,3 +203,5 @@ tunnel_net_ips:
   mon1: 10.217.1.0
   net1: 10.217.1.4
   net2: 10.217.1.12
+ilab_net_ips:
+  cumulus-seed: 10.60.150.1

--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -54,6 +54,9 @@ inspection_net_name: inspection_net
 # hosts
 cleaning_net_name: cleaning_net
 
+# Name of the network used for admin access to the deployment
+ilab_net_name: ilab_net
+
 ###############################################################################
 # Network definitions.
 
@@ -191,11 +194,20 @@ inspection_net_inspection_allocation_pool_end: "10.{{ inspection_net_vlan }}.102
 # inspection_net_mtu:
 # inspection_net_routes:
 
+# Cambridge ilab network IP information.
+ilab_net_vlan: 60
+ilab_net_cidr: "10.{{ ilab_net_vlan }}.0.0/16"
+ilab_net_routes:
+  # Default route onto the Cambridge ilab network
+  - cidr: "0.0.0.0/0"
+    gateway: "10.60.255.1"
+
 # 1G and external stays on default mtu
 provision_oc_net_mtu: 1500
 public_net_mtu: 1500
 admin_oc_net_mtu: 1500
 oob_oc_net_mtu: 1500
+ilab_net_mtu: 1500
 
 # TODO: we want these to be 9000
 br_net_mtu: 1500

--- a/etc/kayobe/seed.yml
+++ b/etc/kayobe/seed.yml
@@ -22,6 +22,7 @@ seed_extra_network_interfaces:
   - internal_net
   - external_net
   - storage_mgmt_net
+  - ilab_net
 
 ###############################################################################
 # LVM configuration.


### PR DESCRIPTION
Statically assigns an IP to the interface on the ilab network
and sets up the ilab network as the default gateway on the seed node.