### PR TITLE
Workaround to restart fluentd on demand

### DIFF
--- a/etc/kayobe/ansible/restart_fluentd.yml
+++ b/etc/kayobe/ansible/restart_fluentd.yml
@@ -1,0 +1,10 @@
+---
+- name: Restart Fluentd across the overcloud
+  hosts: overcloud
+  become: yes
+  gather_facts: no
+  tasks:
+  - name: Restart Fluentd
+    docker_container:
+      name: fluentd
+      restart: yes


### PR DESCRIPTION
This is useful for restarting Fluentd if for example ES goes down
and the output plugin exceeds the max number of retries, or the retry
interval is too long.