### PR TITLE
Do not deploy chrony container

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -61,3 +61,7 @@ prometheus_libvirt_exporter_tag: 7.0.1.4
 rabbitmq_tag: rocky
 storm_tag: rocky
 zookeeper_tag: rocky
+
+# Kayobe currently configures ntpd on each node in the overcloud
+enable_chrony: false
+enable_host_ntp: true


### PR DESCRIPTION
Currently kayobe can only configure ntpd:

https://storyboard.openstack.org/#!/story/2005272

I have not tested to see if this works. It would also rely on: https://github.com/resmo/ansible-role-ntp/pull/27