### PR TITLE
Update firewall for seed node

### DIFF
--- a/etc/kayobe/inventory/group_vars/seed/firewall
+++ b/etc/kayobe/inventory/group_vars/seed/firewall
@@ -11,8 +11,16 @@ firewallgen_ipv4_input_allow_rules:
   - interface: "lo"
     port: 53
     proto: tcp
+    comment: "hint: used by 'dnsmasq' in docker container 'bifrost_deploy'"
+  - interface: "lo"
+    port: 53
+    proto: tcp
     destination: "127.0.0.1"
     comment: "hint: used by 'dnsmasq' in docker container 'bifrost_deploy'"
+  - interface: "lo"
+    port: 3306
+    proto: tcp
+    comment: "hint: used by 'mysqld' in docker container 'bifrost_deploy'"
   - interface: "lo"
     port: 4369
     proto: tcp
@@ -21,6 +29,10 @@ firewallgen_ipv4_input_allow_rules:
     port: 5050
     proto: tcp
     comment: "hint: used by 'ironic-inspecto' in docker container 'bifrost_deploy'"
+  - interface: "lo"
+    port: 5672
+    proto: tcp
+    comment: "hint: used by 'beam.smp' in docker container 'bifrost_deploy'"
   - interface: "lo"
     port: 25672
     proto: tcp
@@ -34,16 +46,6 @@ firewallgen_ipv4_input_allow_rules:
     proto: tcp
     destination: "{{ ilab_net_name | net_ip }}"
     comment: "SSH via ILAB"
-  - interface: "{{ internal_net_name | net_interface }}"
-    port: 9197
-    proto: tcp
-    destination: "{{ internal_net_name | net_ip }}"
-    comment: "mtail"
-  - interface: "{{ internal_net_name | net_interface }}"
-    port: 18080
-    proto: tcp
-    destination: "{{ internal_net_name | net_ip }}"
-    comment: "cadvisor"
   - interface: "{{ provision_oc_net_interface }}"
     port: 53
     proto: tcp
@@ -57,15 +59,19 @@ firewallgen_ipv4_input_allow_rules:
     port: 8080
     proto: tcp
     comment: "hint: used by 'nginx' in docker container 'bifrost_deploy'"
+  - interface: "{{ provision_oc_net_name | net_interface }}"
+    port: 4000
+    proto: tcp
+    comment: "hint: used by 'docker-proxy'"
   - interface: "docker0"
     port: 123
     proto: udp
     destination: "172.17.0.1"
     comment: "hint: used by 'ntpd'"
-  - interface: "{{ provision_oc_net_name | net_interface }}"
-    port: 5000
-    proto: tcp
-    destination: "{{ provision_oc_net_name | net_ip }}"
+  - interface: "lo"
+    port: 53
+    proto: udp
+    comment: "hint: used by 'dnsmasq' in docker container 'bifrost_deploy'"
   - interface: "lo"
     port: 53
     proto: udp

--- a/etc/kayobe/inventory/group_vars/seed/firewall-extra
+++ b/etc/kayobe/inventory/group_vars/seed/firewall-extra
@@ -1,0 +1,11 @@
+---
+
+firewallgen_ipv4_forward_allow:
+  - in-interface: "{{ ilab_net_interface }}"
+    out-interface: "{{ admin_oc_net_name | net_interface }}"
+    state: RELATED,ESTABLISHED
+  - in-interface: "{{ admin_oc_net_name | net_interface }}"
+    out-interface: "{{ ilab_net_interface }}"
+     
+firewallgen_ipv4_snat:
+  - out-interface: "{{ ilab_net_interface }}"

--- a/etc/kayobe/inventory/group_vars/seed/firewallgen
+++ b/etc/kayobe/inventory/group_vars/seed/firewallgen
@@ -19,15 +19,20 @@ firewallgen_ipv4_input_allow_rewrite_rules_extra:
   - '. |= map( if .port == 4369 and .proto == "tcp"  then .interface = "lo" else . end)'
 # rabbit (doesn't seem to referenced in any config file)
   - '. |= map( if .port == 25672 and .proto == "tcp"  then .interface = "lo" else . end)'
+# bifrost mysql
+  - '. |= map( if .port == 3306 and .proto == "tcp"  then .interface = "lo" else . end)'
+# bifrost rabbitmq
+  - '. |= map( if .port == 5672 and .proto == "tcp"  then .interface = "lo" else . end)'
+# DNS ?
+  - '. |= map( if .port == 53 then .interface = "lo" else . end)'
+# docker-proxy for docker regsitry
+  - >-
+    . |= map( if .port == 4000 and .proto == "tcp" then
+            .interface = "{{ firewallgen_interface_tmpl % 'provision_oc_net_name' }}" else . end)
 
 firewallgen_ipv4_input_allow_custom_rules_extra:
-  # These are ipv4-mapped ipv6 addresses and don't show in ss -nlpt -4 output
-  - interface: "{{ firewallgen_interface_tmpl % 'provision_oc_net_name' }}"
-    port: 5000
-    proto: tcp
-    destination: "{% raw %}{{ provision_oc_net_name | net_ip }}{% endraw %}"
-  - interface: "{{ firewallgen_interface_tmpl % 'ilab_net_name' }}"
-    port: 22
-    proto: tcp
-    destination: "{% raw %}{{ ilab_net_name | net_ip }}{% endraw %}"
-    comment: SSH via ILAB
+ - interface: "{{ firewallgen_interface_tmpl % 'ilab_net_name' }}"
+   port: 22
+   proto: tcp
+   destination: "{% raw %}{{ ilab_net_name | net_ip }}{% endraw %}"
+   comment: SSH via ILAB


### PR DESCRIPTION
- mtail and cadvisor rules removed (these services aren't currently running)
- add ipv4-mapped-ipv6 ports
- remove port 5000 for docker registry

Currently docker is managing iptables so it will add its own rules to allow traffic
for the registry:

*nat
-A DOCKER ! -i docker0 -p tcp -m tcp --dport 4000 -j DNAT --to-destination 172.17.0.2:5000
-A POSTROUTING -s 172.17.0.2/32 -d 172.17.0.2/32 -p tcp -m tcp --dport 5000 -j MASQUERADE
COMMIT

*filter
-A DOCKER -d 172.17.0.2/32 ! -i docker0 -o docker0 -p tcp -m tcp --dport 5000 -j ACCEPT
COMMIT

We may want to look at using the --iptables=false option for the docker daemon and
templating all of these rules. However, if you can spawn arbitrary containers
you effectively have root permissions and could add any iptables rules you
wanted.