### PR TITLE
Try to stop fluentd stopping sending to elastic

### DIFF
--- a/etc/kayobe/kolla/config/fluentd/output/01-es.conf
+++ b/etc/kayobe/kolla/config/fluentd/output/01-es.conf
@@ -9,6 +9,8 @@
        logstash_format true
        logstash_prefix audit
        flush_interval 15s
+       reload_connections false
+       reconnect_on_error true
     </store>
 </match>
 
@@ -23,6 +25,8 @@
        logstash_format true
        logstash_prefix apel
        flush_interval 15s
+       reload_connections false
+       reconnect_on_error true
     </store>
 </match>
 
@@ -38,6 +42,8 @@
        logstash_prefix {% raw %}{{ kibana_log_prefix }}
 {% endraw %}
        flush_interval 15s
+       reload_connections false
+       reconnect_on_error true
     </store>
 </match>
 
@@ -52,5 +58,7 @@
        logstash_format true
        logstash_prefix unmatched
        flush_interval 15s
+       reload_connections false
+       reconnect_on_error true
     </store>
 </match>


### PR DESCRIPTION
reload_connections false

The above is chosen as we are behind haproxy, so we should not reload
the list of hosts from elasticsearch.

reconnect_on_error true

Normally connections are not reconnected on error, so eventually the
pool is full, but all the connections are hung. Seems like this happens
after the 10,000 requests that trigger the above reload, or maybe when
haproxy fails over to a new host. Its not totally clear.