### PR TITLE
Fix up swift endpoints in keystone

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -33,6 +33,12 @@ prometheus_jiralert_project: 'SO'
 prometheus_jiralert_user: 'doug@stackhpc.com'
 prometheus_jiralert_default_receiver_name: 'default'
 
+# We use rgw swift account in url = True
+# so we need to override the swift enpoint
+swift_admin_endpoint: "http://10.205.0.1:6780/swift/v1/AUTH_%(tenant_id)s"
+swift_internal_endpoint: "http://10.205.0.1:6780/swift/v1/AUTH_%(tenant_id)s"
+swift_public_endpoint: "https://cumulus.openstack.hpc.cam.ac.uk:6780/swift/v1/AUTH_%(tenant_id)s"
+
 # Projects to extracts metrics from with cASO
 caso_projects:
   - iris

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -12,7 +12,10 @@ nova_instance_datadir_volume: '/var/lib/nova'
 
 # Ceph integration, without nova having rbd backend
 cinder_backend_ceph: "yes"
-#glance_backend_ceph: "yes"
+
+# Make glance use Ceph via the Swift API
+glance_backend_swift: "yes"
+glance_file_backend: "no"
 
 # Enable CADF notifications in Keystone
 enable_cadf_notifications: "yes"


### PR DESCRIPTION
Hard override to avoid another kolla-ansible change for now.
Need to add the project_id into the URL, using tenant_id to be
consistent.

Working towards the configuration mentioned here:
https://docs.openstack.org/ironic/stein/admin/radosgw.html