### PR TITLE
Move to hyperthreading off

### DIFF
--- a/etc/kayobe/kolla/config/nova.conf
+++ b/etc/kayobe/kolla/config/nova.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-vcpu_pin_set=8-63
+vcpu_pin_set=4-31
 default_ephemeral_format=ext4
 force_raw_images=False
 use_cow_images=False
@@ -8,9 +8,9 @@ preallocate_images=space
 reserved_host_memory_mb=9216
 # 39GB for local image cache
 reserved_host_disk_mb=39936
-initial_cpu_allocation_ratio=1.0
+initial_cpu_allocation_ratio=2.0
 initial_ram_allocation_ratio=1.0
-cpu_allocation_ratio=1.0
+cpu_allocation_ratio=2.0
 ram_allocation_ratio=1.0
 
 [libvirt]


### PR DESCRIPTION
To keep the flavors the same, but hyperthreading off
cpu allocation ratio is doubled
vcpu pin set updated to reserve 4 cores rather than 8