### PR TITLE
Magnum train preprod

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -72,7 +72,7 @@ kibana_tag: 7.0.1.10
 kolla_toolbox_tag: 7.0.1.10
 logstash_tag: 7.0.1.10
 octavia_tag: stein
-magnum_tag: stein
+magnum_tag: train
 manila_tag: 7.0.1.10
 mariadb_tag: 7.0.1.10
 memcached_tag: 7.0.1.10


### PR DESCRIPTION
This is to support latest kube_tags with `use_podman` label