### PR TITLE
DNM: Set base path

### DIFF
--- a/etc/kayobe/globals.yml
+++ b/etc/kayobe/globals.yml
@@ -11,7 +11,7 @@
 # Remote path configuration (seed, seed-hypervisor and overcloud hosts).
 
 # Base path for kayobe state on remote hosts.
-#base_path:
+base_path: "{{ ansible_env.HOME/.kayobe }}"
 
 # Path in which to cache downloaded images on remote hosts.
 #image_cache_path:


### PR DESCRIPTION
When using kayobe with multiple users, you will hit:

```
TASK [Ensure Ironic Python Agent images are copied onto the local machine] **************************************************************************************************
ok: [cpu-e-1041] => (item={u'dest': u'ipa.vmlinuz', u'src': u'ipa.vmlinuz'})
 [WARNING]: sftp transfer mechanism failed on [10.200.4.0]. Use ANSIBLE_DEBUG=1 to see detailed information
 [WARNING]: scp transfer mechanism failed on [10.200.4.0]. Use ANSIBLE_DEBUG=1 to see detailed information
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: IOError: [Errno 13] Permission denied: '/opt/kayobe/images/ipa/ipa.initramfs
'
fatal: [cpu-e-1041]: FAILED! =>
  msg: Unexpected failure during module execution.
  stdout: ''
```

with the default base path when you use the seed as the ansible control host. This sets the base
to a directory in the users home directory to avoid this permissions conflict.