### PR TITLE
Specify es_heap_size

### DIFF
--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -97,6 +97,9 @@ zookeeper_tag: 7.0.1.10
 enable_chrony: false
 enable_host_ntp: true
 
+# Default size causes ES to fall over very easily
+es_heap_size: "24g"
+
 # Use upstream magnum images for these
 magnum_api_image: "{% raw %}kolla/{{ kolla_base_distro }}-{{ magnum_install_type }}-magnum-api{% endraw %}"
 magnum_conductor_image: "{% raw %}kolla/{{ kolla_base_distro }}-{{ magnum_install_type }}-magnum-conductor{% endraw %}"


### PR DESCRIPTION
This resolves an issue where elastic search would run out of
memory:

java.lang.OutOfMemoryError: Java heap space

In the elastic search container.