### PR TITLE
Set Nova Live Migration inbound address

### DIFF
--- a/etc/kayobe/inventory/group_vars/compute/firewall
+++ b/etc/kayobe/inventory/group_vars/compute/firewall
@@ -48,6 +48,11 @@ firewallgen_ipv4_input_allow_rules:
     destination: "{{ internal_net_name | net_ip }}"
     comment: "hint: used by 'mtail' in docker container 'prometheus_mtail'"
   - interface: "{{ internal_net_name | net_interface }}"
+    port: 10000:20000
+    proto: tcp
+    destination: "{{ internal_net_name | net_ip }}"
+    comment: "Nova serial console proxy"
+  - interface: "{{ internal_net_name | net_interface }}"
     port: 18080
     proto: tcp
     destination: "{{ internal_net_name | net_ip }}"

--- a/etc/kayobe/kolla/config/nova/nova-compute.conf
+++ b/etc/kayobe/kolla/config/nova/nova-compute.conf
@@ -1,0 +1,2 @@
+[libvirt]
+live_migration_inbound_addr = {% raw %}{{ api_interface_address }}{% endraw %}


### PR DESCRIPTION
Set the inbound live migration IP address on nova-computes explicitly, this is done in order to side-step some observed issues with stale host name resolution in running containers.